### PR TITLE
Fix node drop error

### DIFF
--- a/src/components/flow/flow-hooks/useNodeDragStop.js
+++ b/src/components/flow/flow-hooks/useNodeDragStop.js
@@ -6,39 +6,52 @@ const useNodeDragStop = ({ nodes, setNodes }) => {
     return useCallback((evt, node) => {
         // ----------- SUBNETWORK SOLO DENTRO DE VPC -----------
         if (node.type === TYPE_SUBNETWORK_NODE) {
-            const vpcTarget = nodes.find((nd) => {
+            let vpcTarget = nodes.find((nd) => nd.id === node.parentNode && nd.type === TYPE_VPC_NODE);
+
+            if (!vpcTarget) {
+                vpcTarget = nodes.find((nd) => {
                 // Validación defensiva
                 if (
                     typeof nd !== "object" ||
                     nd == null ||
                     nd.type !== TYPE_VPC_NODE ||
                     typeof nd.position !== "object" ||
-                    nd.position == null ||
-                    typeof nd.position.x !== "number" ||
-                    typeof nd.position.y !== "number"
+                    nd.position == null
                 ) {
-                    // Log para rastrear descartes
-                    // console.warn("Nodo VPC descartado por posición inválida", nd);
                     return false;
                 }
+
+                const nodePosX = node.positionAbsolute?.x ?? node.position.x;
+                const nodePosY = node.positionAbsolute?.y ?? node.position.y;
+
+                const targetPosX = nd.positionAbsolute?.x ?? nd.position.x;
+                const targetPosY = nd.positionAbsolute?.y ?? nd.position.y;
+
                 // Validar bounds
                 return (
-                    node.positionAbsolute.x + (node.width || 0) / 2 > nd.position.x &&
-                    node.positionAbsolute.x + (node.width || 0) / 2 < nd.position.x + (nd.style?.width || nd.width || 0) &&
-                    node.positionAbsolute.y + (node.height || 0) / 2 > nd.position.y &&
-                    node.positionAbsolute.y + (node.height || 0) / 2 < nd.position.y + (nd.style?.height || nd.height || 0)
+                    nodePosX + (node.width || 0) / 2 > targetPosX &&
+                    nodePosX + (node.width || 0) / 2 < targetPosX + (nd.style?.width || nd.width || 0) &&
+                    nodePosY + (node.height || 0) / 2 > targetPosY &&
+                    nodePosY + (node.height || 0) / 2 < targetPosY + (nd.style?.height || nd.height || 0)
                 );
-            });
+                });
+            }
 
-            if (vpcTarget && vpcTarget.position) {
-                const xOffset = node.positionAbsolute.x - vpcTarget.position.x;
-                const yOffset = node.positionAbsolute.y - vpcTarget.position.y;
+            if (vpcTarget && (vpcTarget.position || vpcTarget.positionAbsolute)) {
+                const nodeAbsX = node.positionAbsolute?.x ?? node.position.x;
+                const nodeAbsY = node.positionAbsolute?.y ?? node.position.y;
+                const targetAbsX = vpcTarget.positionAbsolute?.x ?? vpcTarget.position.x;
+                const targetAbsY = vpcTarget.positionAbsolute?.y ?? vpcTarget.position.y;
+
+                const xOffset = nodeAbsX - targetAbsX;
+                const yOffset = nodeAbsY - targetAbsY;
                 setNodes((prevNodes) =>
                     prevNodes.map((n) =>
                         n.id === node.id
                             ? {
                                   ...n,
                                   parentNode: vpcTarget.id,
+                                  parentId: vpcTarget.id,
                                   extent: 'parent',
                                   position: { x: xOffset, y: yOffset },
                               }
@@ -53,39 +66,52 @@ const useNodeDragStop = ({ nodes, setNodes }) => {
 
         // ----------- INSTANCIAS SOLO DENTRO DE SUBNET -----------
         if (restrictedNodes.includes(node.type)) {
-            const subnetTarget = nodes.find((nd) => {
+            let subnetTarget = nodes.find((nd) => nd.id === node.parentNode && nd.type === TYPE_SUBNETWORK_NODE);
+
+            if (!subnetTarget) {
+                subnetTarget = nodes.find((nd) => {
                 // Validación defensiva
                 if (
                     typeof nd !== "object" ||
                     nd == null ||
                     nd.type !== TYPE_SUBNETWORK_NODE ||
                     typeof nd.position !== "object" ||
-                    nd.position == null ||
-                    typeof nd.position.x !== "number" ||
-                    typeof nd.position.y !== "number"
+                    nd.position == null
                 ) {
-                    // Log para rastrear descartes
-                    // console.warn("Nodo Subnet descartado por posición inválida", nd);
                     return false;
                 }
+
+                const nodePosX = node.positionAbsolute?.x ?? node.position.x;
+                const nodePosY = node.positionAbsolute?.y ?? node.position.y;
+
+                const targetPosX = nd.positionAbsolute?.x ?? nd.position.x;
+                const targetPosY = nd.positionAbsolute?.y ?? nd.position.y;
+
                 // Validar bounds
                 return (
-                    node.positionAbsolute.x + (node.width || 0) / 2 > nd.position.x &&
-                    node.positionAbsolute.x + (node.width || 0) / 2 < nd.position.x + (nd.style?.width || nd.width || 0) &&
-                    node.positionAbsolute.y + (node.height || 0) / 2 > nd.position.y &&
-                    node.positionAbsolute.y + (node.height || 0) / 2 < nd.position.y + (nd.style?.height || nd.height || 0)
+                    nodePosX + (node.width || 0) / 2 > targetPosX &&
+                    nodePosX + (node.width || 0) / 2 < targetPosX + (nd.style?.width || nd.width || 0) &&
+                    nodePosY + (node.height || 0) / 2 > targetPosY &&
+                    nodePosY + (node.height || 0) / 2 < targetPosY + (nd.style?.height || nd.height || 0)
                 );
-            });
+                });
+            }
 
-            if (subnetTarget && subnetTarget.position) {
-                const xOffset = node.positionAbsolute.x - subnetTarget.position.x;
-                const yOffset = node.positionAbsolute.y - subnetTarget.position.y;
+            if (subnetTarget && (subnetTarget.position || subnetTarget.positionAbsolute)) {
+                const nodeAbsX = node.positionAbsolute?.x ?? node.position.x;
+                const nodeAbsY = node.positionAbsolute?.y ?? node.position.y;
+                const targetAbsX = subnetTarget.positionAbsolute?.x ?? subnetTarget.position.x;
+                const targetAbsY = subnetTarget.positionAbsolute?.y ?? subnetTarget.position.y;
+
+                const xOffset = nodeAbsX - targetAbsX;
+                const yOffset = nodeAbsY - targetAbsY;
                 setNodes((prevNodes) =>
                     prevNodes.map((n) =>
                         n.id === node.id
                             ? {
                                   ...n,
                                   parentNode: subnetTarget.id,
+                                  parentId: subnetTarget.id,
                                   extent: 'parent',
                                   position: { x: xOffset, y: yOffset },
                               }


### PR DESCRIPTION
## Summary
- handle missing positionAbsolute when dropping nodes
- set parentId along with parentNode when reparenting
- don't warn when repositioning nodes within their current parent

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687fb87d683c83328724f9a53b36e81c