### PR TITLE
fix: render instance nodes inside subnetworks

### DIFF
--- a/src/components/flow/flow-hooks/useRestrictMovement.js
+++ b/src/components/flow/flow-hooks/useRestrictMovement.js
@@ -1,24 +1,23 @@
 // useRestrictMovement.js
 import { useCallback } from 'react';
-import { useReactFlow } from '@xyflow/react';
 
 export default function useRestrictMovement(reactFlowInstance, setNodes) {
   const onNodeDragStop = useCallback((_, node) => {
     if (!reactFlowInstance) return;
-    const parentId = node.parentId;
+    const parentId = node.parentNode || node.parentId;
     if (!parentId) return;
 
     const parent = reactFlowInstance.getNode(parentId);
     if (!parent) return;
 
-    const nodeAbs = reactFlowInstance.getInternalNode(node.id);
-    const parentAbs = reactFlowInstance.getInternalNode(parentId);
-    if (!nodeAbs || !parentAbs) return;
+      const nodeAbs = reactFlowInstance.getInternalNode(node.id);
+      const parentAbs = reactFlowInstance.getInternalNode(parentId);
+      if (!nodeAbs?.positionAbsolute || !parentAbs?.positionAbsolute) return;
 
-    const { x: nx, y: ny } = nodeAbs.positionAbsolute;
-    const nw = node.width || node.style?.width; const nh = node.height || node.style?.height;
-    const { x: px, y: py } = parentAbs.positionAbsolute;
-    const pw = parent.width || parent.style?.width; const ph = parent.height || parent.style?.height;
+      const { x: nx, y: ny } = nodeAbs.positionAbsolute;
+      const nw = node.width || node.style?.width; const nh = node.height || node.style?.height;
+      const { x: px, y: py } = parentAbs.positionAbsolute;
+      const pw = parent.width || parent.style?.width; const ph = parent.height || parent.style?.height;
 
     let clampedX = node.position.x;
     let clampedY = node.position.y;


### PR DESCRIPTION
## Summary
- ensure dropped nodes register parent subnet using node positions
- clamp movement using parentNode or parentId

## Testing
- `npm run lint` *(fails: 65 problems (61 errors, 4 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6890baff0cc48332bf962377a425c752