### PR TITLE
refactor: polish node styles for professional look

### DIFF
--- a/src/components/flow/node-types/InstanceNode.jsx
+++ b/src/components/flow/node-types/InstanceNode.jsx
@@ -12,7 +12,7 @@ const InstanceNode = ({ data, type }) => {
     const titleNode = data.title
 
     return (
-        <Paper elevation={3} className="instance-node" style={{ backgroundColor: '#fff', padding: 10 }}>
+        <Paper elevation={3} className="instance-node">
             <Typography variant="h6" className="instance-node-title">{titleNode}</Typography>
             <Box className="instance-icon-container">
                 {getIconByInstanceType(type)}
@@ -22,4 +22,4 @@ const InstanceNode = ({ data, type }) => {
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export default memo(InstanceNode)
+export default memo(InstanceNode);

--- a/src/components/flow/node-types/RouterNodeInstance.jsx
+++ b/src/components/flow/node-types/RouterNodeInstance.jsx
@@ -5,7 +5,7 @@ import './styles/RouterNode.css';
 
 const RouterNodeInstance = ({ id, title = "ROUTER" }) => {
     return (
-        <Paper elevation={3} className="router-node" style={{ backgroundColor: '#fff' }}>
+        <Paper elevation={3} className="router-node">
             {title && <Typography variant="h6" className="router-node-title">{title}</Typography>}
             <Box className="router">
                 <Box className="circle">

--- a/src/components/flow/node-types/SubNetworkNodeInstance.jsx
+++ b/src/components/flow/node-types/SubNetworkNodeInstance.jsx
@@ -22,7 +22,7 @@ function SubNetworkNodeInstance({ data, isConnectable }) {
         // eslint-disable-next-line react/prop-types
         style={{ backgroundColor: data.bgNode }}>
         <NodeResizer minWidth={180} minHeight={100} />
-        <Box sx={{ padding: 1 }} style={{ backgroundColor: '#00008b' }}>
+        <Box sx={{ p: 1, backgroundColor: '#1976d2', color: '#fff' }}>
           <Typography>{titleNode} {data.subnetName}</Typography>
         </Box>
         <Handle

--- a/src/components/flow/node-types/VPCNodeInstance.jsx
+++ b/src/components/flow/node-types/VPCNodeInstance.jsx
@@ -9,7 +9,7 @@ function VPCNodeInstance({ data, isConnectable }) {
     return (
         <Paper className='node-vpc' elevation={3}
             sx={{ position: 'relative', minWidth: 600, minHeight: 400 }}
-            style={{ backgroundColor: data.bgColor || '#e8eaf6' }}>
+            style={{ backgroundColor: data.bgColor || '#f7f9fc' }}>
 
             <NodeResizer minWidth={600} minHeight={400} />
             <Box sx={{ padding: 1, backgroundColor: '#0B8068', color: 'white' }}>

--- a/src/components/flow/node-types/styles/InstanceNode.css
+++ b/src/components/flow/node-types/styles/InstanceNode.css
@@ -1,22 +1,23 @@
-.instance-node{
-    padding: 10px;
-    border: 2px solid #3f51b5;
-    border-radius: 10px;
+.instance-node {
+    padding: 8px;
+    border: 1px solid #1976d2;
+    border-radius: 6px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 100%;  /* Ajusta el ancho según sea necesario */
-    height: 100%; /* Ajusta la altura según sea necesario */
-    background-color: #e3f2fd; 
+    width: 100%;
+    height: 100%;
+    background-color: #f7f9fc;
 }
 
-.instance-node-title{
+.instance-node-title {
     text-align: center;
-    margin-bottom: 10px;
-    color: #3f51b5;
+    margin-bottom: 4px;
+    color: #0d47a1;
+    font-weight: 600;
 }
 
-.instance-node-icon-container{
+.instance-icon-container {
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/flow/node-types/styles/RouterNode.css
+++ b/src/components/flow/node-types/styles/RouterNode.css
@@ -1,18 +1,20 @@
 .router-node {
-    padding: 10px;
-    border: 2px solid #000;
-    border-radius: 10px;
+    padding: 8px;
+    border: 1px solid #1976d2;
+    border-radius: 6px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 100%;  /* Ajusta el ancho según sea necesario */
-    height: 100%; /* Ajusta la altura según sea necesario */
+    width: 100%;
+    height: 100%;
+    background-color: #f7f9fc;
 }
 
 .router-node-title {
     text-align: center;
-    margin-bottom: 10px;
-    color: #000;
+    margin-bottom: 4px;
+    color: #0d47a1;
+    font-weight: 600;
 }
 
 .router {
@@ -27,7 +29,7 @@
 .circle {
     width: 80px;
     height: 80px;
-    border: 2px solid purple;
+    border: 2px solid #1976d2;
     border-radius: 50%;
     position: relative;
     display: flex;
@@ -39,14 +41,14 @@
     position: absolute;
     width: 100%;
     height: 2px;
-    background-color: purple;
+    background-color: #1976d2;
 }
 
 .vertical-line {
     position: absolute;
     width: 2px;
     height: 100%;
-    background-color: purple;
+    background-color: #1976d2;
 }
 
 .arrow {
@@ -58,26 +60,24 @@
 
 .up {
     border-width: 0 5px 10px 5px;
-    border-color: transparent transparent purple transparent;
-    top: 0px;
+    border-color: transparent transparent #1976d2 transparent;
+    top: -2px;
 }
 
 .router-node .right {
     border-width: 5px 0 5px 10px;
-    border-color: transparent transparent transparent purple;
-    right: 0px;
+    border-color: transparent transparent transparent #1976d2;
+    right: -2px;
 }
 
 .down {
     border-width: 10px 5px 0 5px;
-    border-color: purple transparent transparent transparent;
-    bottom: 0px;
+    border-color: #1976d2 transparent transparent transparent;
+    bottom: -2px;
 }
 
 .router-node .left {
-
     border-width: 5px 10px 5px 0;
-    border-color: transparent purple transparent transparent;
-    left: 0px;
-   
+    border-color: transparent #1976d2 transparent transparent;
+    left: -2px;
 }

--- a/src/components/flow/node-types/styles/SubNetworkNode.css
+++ b/src/components/flow/node-types/styles/SubNetworkNode.css
@@ -1,9 +1,9 @@
-.node-subnetwork{
+.node-subnetwork {
     width: 100%;
     height: 100%;
-    border-radius: 15px;
-    border: 1px solid #000;
-    background-color: #fff;
-    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid #1976d2;
+    background-color: #f7f9fc;
+    padding: 16px;
     box-sizing: border-box;
 }

--- a/src/components/flow/node-types/styles/VPCNode.css
+++ b/src/components/flow/node-types/styles/VPCNode.css
@@ -1,7 +1,7 @@
 .node-vpc {
-  border: 3px dashed #0B8068;
-  border-radius: 16px;
-  background-color: #e8eaf6;
+  border: 2px dashed #1976d2;
+  border-radius: 8px;
+  background-color: #f7f9fc;
   width: 100%;
   height: 100%;
   overflow: visible;


### PR DESCRIPTION
## Summary
- unify styling across Instance, Router, Subnetwork and VPC nodes for a clean professional look
- remove inline styles and fix class names in node components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 61 errors, 4 warnings)


------
https://chatgpt.com/codex/tasks/task_e_6890f9b9b1448332b42b8847137b273a