### PR TITLE
Add router and VPC node configuration modals

### DIFF
--- a/src/components/flow/MainFlow.jsx
+++ b/src/components/flow/MainFlow.jsx
@@ -39,6 +39,8 @@ import useRestoreFlow from './flow-hooks/useRestoreFlow';
 import useSaveFlow from './flow-hooks/useSaveFlow';
 import InstanceNodeForm from './forms/InstanceNodeForm';
 import SubNetworkNodeForm from './forms/SubNetworkNodeForm';
+import RouterNodeForm from './forms/RouterNodeForm';
+import VPCNodeForm from './forms/VPCNodeForm';
 import InstanceNode from "./node-types/InstanceNode";
 import RouterNodeInstance from "./node-types/RouterNodeInstance";
 import VPCNodeInstance from "./node-types/VPCNodeInstance";
@@ -95,7 +97,7 @@ const nodeTypes = {
 }
 
 
-const restrictedNodes = [TYPE_DEFAULT_NODE, TYPE_COMPUTER_NODE, TYPE_PRINTER_NODE, TYPE_SERVER_NODE, TYPE_SUBNETWORK_NODE]
+const restrictedNodes = [TYPE_DEFAULT_NODE, TYPE_COMPUTER_NODE, TYPE_PRINTER_NODE, TYPE_SERVER_NODE]
 
 
 const makeRandomId = (length) => {
@@ -480,9 +482,12 @@ function MainFlow() {
                         {selectedNode && selectedNode.type === TYPE_SUBNETWORK_NODE && (
                             <SubNetworkNodeForm nodeData={selectedNode.data} onSave={saveNodeData} cidrBlockVPC={cidrBlockVPC} deleteNode={deleteNodeInstance} />
                         )}
-                        {/* {selectedNode && selectedNode.type === TYPE_ROUTER_NODE && (
+                        {selectedNode && selectedNode.type === TYPE_ROUTER_NODE && (
                             <RouterNodeForm nodeData={selectedNode.data} onSave={saveNodeData} cidrBlockVPC={cidrBlockVPC} deleteNode={deleteNodeInstance} />
-                        )} */}
+                        )}
+                        {selectedNode && selectedNode.type === TYPE_VPC_NODE && (
+                            <VPCNodeForm nodeData={selectedNode.data} onSave={saveNodeData} deleteNode={deleteNodeInstance} />
+                        )}
 
 
                     </Box>

--- a/src/components/flow/forms/VPCNodeForm.jsx
+++ b/src/components/flow/forms/VPCNodeForm.jsx
@@ -1,0 +1,64 @@
+import { Button, FormControl, InputLabel, MenuItem, Select, TextField } from "@mui/material";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useFormValidationSchema } from "./validations/useFormValidations";
+import { CLOUD_AWS_LABEL, CLOUD_AWS_VALUE, VPC_FORM } from "../utils/constants";
+
+// eslint-disable-next-line react/prop-types
+const VPCNodeForm = ({ nodeData, onSave, deleteNode }) => {
+  const validationSchema = useFormValidationSchema(VPC_FORM, true);
+  const { register, handleSubmit, formState: { errors } } = useForm({
+    resolver: yupResolver(validationSchema),
+    defaultValues: {
+      cloudProvider: nodeData.cloudProvider || CLOUD_AWS_VALUE,
+      vpcName: nodeData.vpcName || "",
+      cidrBlock: nodeData.cidrBlock && nodeData.prefixLength ? `${nodeData.cidrBlock}/${nodeData.prefixLength}` : "",
+    }
+  });
+
+  const onSubmit = (data) => {
+    const [base, prefix] = data.cidrBlock.split("/");
+    onSave({ ...data, cidrBlock: base, prefixLength: prefix });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <FormControl fullWidth>
+        <InputLabel id="vpc-cloud-label">Cloud Provider</InputLabel>
+        <Select
+          labelId="vpc-cloud-label"
+          {...register("cloudProvider")}
+          label="Cloud Provider"
+          defaultValue={CLOUD_AWS_VALUE}
+        >
+          <MenuItem value={CLOUD_AWS_VALUE}>{CLOUD_AWS_LABEL}</MenuItem>
+        </Select>
+        {errors.cloudProvider && <p>{errors.cloudProvider.message}</p>}
+      </FormControl>
+
+      <TextField
+        label="Nombre de la VPC"
+        {...register("vpcName")}
+        error={!!errors.vpcName}
+        helperText={errors.vpcName?.message}
+        fullWidth
+        margin="normal"
+      />
+
+      <TextField
+        label="CIDR Block (ej: 192.168.0.0/24)"
+        {...register("cidrBlock")}
+        error={!!errors.cidrBlock}
+        helperText={errors.cidrBlock?.message}
+        fullWidth
+      />
+
+      <Button type="submit" variant="contained" color="primary">
+        Registrar Configuración
+      </Button>
+      <Button onClick={deleteNode}>Delete Node</Button>
+    </form>
+  );
+};
+
+export default VPCNodeForm;


### PR DESCRIPTION
## Summary
- enable router node configuration modal
- add VPC node configuration form and modal support

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 66 errors, 4 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689110bcc7bc833293652d175b3b40c8