### PR TITLE
Add router and VPC node configuration modals and restrict subnetwork connections

### DIFF
--- a/src/components/flow/MainFlow.jsx
+++ b/src/components/flow/MainFlow.jsx
@@ -39,6 +39,8 @@ import useRestoreFlow from './flow-hooks/useRestoreFlow';
 import useSaveFlow from './flow-hooks/useSaveFlow';
 import InstanceNodeForm from './forms/InstanceNodeForm';
 import SubNetworkNodeForm from './forms/SubNetworkNodeForm';
+import RouterNodeForm from './forms/RouterNodeForm';
+import VPCNodeForm from './forms/VPCNodeForm';
 import InstanceNode from "./node-types/InstanceNode";
 import RouterNodeInstance from "./node-types/RouterNodeInstance";
 import VPCNodeInstance from "./node-types/VPCNodeInstance";
@@ -95,7 +97,7 @@ const nodeTypes = {
 }
 
 
-const restrictedNodes = [TYPE_DEFAULT_NODE, TYPE_COMPUTER_NODE, TYPE_PRINTER_NODE, TYPE_SERVER_NODE, TYPE_SUBNETWORK_NODE]
+const restrictedNodes = [TYPE_DEFAULT_NODE, TYPE_COMPUTER_NODE, TYPE_PRINTER_NODE, TYPE_SERVER_NODE]
 
 
 const makeRandomId = (length) => {
@@ -480,9 +482,12 @@ function MainFlow() {
                         {selectedNode && selectedNode.type === TYPE_SUBNETWORK_NODE && (
                             <SubNetworkNodeForm nodeData={selectedNode.data} onSave={saveNodeData} cidrBlockVPC={cidrBlockVPC} deleteNode={deleteNodeInstance} />
                         )}
-                        {/* {selectedNode && selectedNode.type === TYPE_ROUTER_NODE && (
+                        {selectedNode && selectedNode.type === TYPE_ROUTER_NODE && (
                             <RouterNodeForm nodeData={selectedNode.data} onSave={saveNodeData} cidrBlockVPC={cidrBlockVPC} deleteNode={deleteNodeInstance} />
-                        )} */}
+                        )}
+                        {selectedNode && selectedNode.type === TYPE_VPC_NODE && (
+                            <VPCNodeForm nodeData={selectedNode.data} onSave={saveNodeData} deleteNode={deleteNodeInstance} />
+                        )}
 
 
                     </Box>

--- a/src/components/flow/flow-hooks/useFlowState.js
+++ b/src/components/flow/flow-hooks/useFlowState.js
@@ -7,31 +7,30 @@ export function useFlowState() {
     const connectionCreated = useRef(false)
 
     const isValidConnection = useCallback((connection, nodes) => {
-        // // // console.log("isValidConnection");
 
         const { source, target } = connection;
         const sourceNode = nodes.find(node => node.id === source);
         const targetNode = nodes.find(node => node.id === target);
-      //  connectionCreated.current = false;
         if (!sourceNode || !targetNode) {
             return false;
         }
-        if (source.type === TYPE_ROUTER_NODE && (sourceNode.disabled || targetNode.disabled)) {
+
+        if (sourceNode.type === TYPE_SUBNETWORK_NODE || targetNode.type === TYPE_SUBNETWORK_NODE) {
+            return false;
+        }
+
+        if (sourceNode.type === TYPE_ROUTER_NODE && (sourceNode.disabled || targetNode.disabled)) {
             return false; // No permitir conexiones con nodos deshabilitados
         }
+
         // Verificar si están dentro del mismo nodo de subnetwork
         const isSameParent = sourceNode.parentNode === targetNode.parentNode;
-        // Verificar si la conexión es entre un nodo subnetwork y un nodo router
-        const isSubnetworkToRouterConnection = (sourceNode.type === TYPE_SUBNETWORK_NODE && targetNode.type === TYPE_ROUTER_NODE) ||
-            (sourceNode.type === TYPE_ROUTER_NODE && targetNode.type === TYPE_SUBNETWORK_NODE);
 
-        const isValid = isSameParent || isSubnetworkToRouterConnection;
-
-        if (isValid) {
+        if (isSameParent) {
             connectionCreated.current = true;
         }
 
-        return isValid;
+        return isSameParent;
 
 
     }, [])

--- a/src/components/flow/forms/VPCNodeForm.jsx
+++ b/src/components/flow/forms/VPCNodeForm.jsx
@@ -1,0 +1,64 @@
+import { Button, FormControl, InputLabel, MenuItem, Select, TextField } from "@mui/material";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useFormValidationSchema } from "./validations/useFormValidations";
+import { CLOUD_AWS_LABEL, CLOUD_AWS_VALUE, VPC_FORM } from "../utils/constants";
+
+// eslint-disable-next-line react/prop-types
+const VPCNodeForm = ({ nodeData, onSave, deleteNode }) => {
+  const validationSchema = useFormValidationSchema(VPC_FORM, true);
+  const { register, handleSubmit, formState: { errors } } = useForm({
+    resolver: yupResolver(validationSchema),
+    defaultValues: {
+      cloudProvider: nodeData.cloudProvider || CLOUD_AWS_VALUE,
+      vpcName: nodeData.vpcName || "",
+      cidrBlock: nodeData.cidrBlock && nodeData.prefixLength ? `${nodeData.cidrBlock}/${nodeData.prefixLength}` : "",
+    }
+  });
+
+  const onSubmit = (data) => {
+    const [base, prefix] = data.cidrBlock.split("/");
+    onSave({ ...data, cidrBlock: base, prefixLength: prefix });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <FormControl fullWidth>
+        <InputLabel id="vpc-cloud-label">Cloud Provider</InputLabel>
+        <Select
+          labelId="vpc-cloud-label"
+          {...register("cloudProvider")}
+          label="Cloud Provider"
+          defaultValue={CLOUD_AWS_VALUE}
+        >
+          <MenuItem value={CLOUD_AWS_VALUE}>{CLOUD_AWS_LABEL}</MenuItem>
+        </Select>
+        {errors.cloudProvider && <p>{errors.cloudProvider.message}</p>}
+      </FormControl>
+
+      <TextField
+        label="Nombre de la VPC"
+        {...register("vpcName")}
+        error={!!errors.vpcName}
+        helperText={errors.vpcName?.message}
+        fullWidth
+        margin="normal"
+      />
+
+      <TextField
+        label="CIDR Block (ej: 192.168.0.0/24)"
+        {...register("cidrBlock")}
+        error={!!errors.cidrBlock}
+        helperText={errors.cidrBlock?.message}
+        fullWidth
+      />
+
+      <Button type="submit" variant="contained" color="primary">
+        Registrar Configuración
+      </Button>
+      <Button onClick={deleteNode}>Delete Node</Button>
+    </form>
+  );
+};
+
+export default VPCNodeForm;

--- a/src/components/flow/node-types/SubNetworkNodeInstance.jsx
+++ b/src/components/flow/node-types/SubNetworkNodeInstance.jsx
@@ -1,18 +1,13 @@
 /* eslint-disable react/prop-types */
 import { memo } from 'react';
-import { Handle, Position, NodeResizer } from "@xyflow/react";
+import { NodeResizer } from "@xyflow/react";
 import './styles/SubNetworkNode.css'
 import { Box, Paper, Typography } from '@mui/material';
 
 // eslint-disable-next-line react/prop-types, react-refresh/only-export-components
-function SubNetworkNodeInstance({ data, isConnectable }) {
+function SubNetworkNodeInstance({ data }) {
 
 
-  const DEFAULT_HANDLE_STYLE = {
-    width: 30,
-    height: 30,
-    bottom: -5,
-  };
   // eslint-disable-next-line react/prop-types
   const titleNode = data.title;
   return (
@@ -25,15 +20,6 @@ function SubNetworkNodeInstance({ data, isConnectable }) {
         <Box sx={{ p: 1, backgroundColor: '#1976d2', color: '#fff' }}>
           <Typography>{titleNode} {data.subnetName}</Typography>
         </Box>
-        <Handle
-          type="source"
-          id='blue'
-          position={Position.Top}
-          style={{ ...DEFAULT_HANDLE_STYLE, left: "50%", background: "blue" }}
-          isConnectable={isConnectable}
-          onConnect={(params) =>  console.log("handle onConnect", params)}
-        />
-     
       </Paper>
 
 


### PR DESCRIPTION
## Summary
- enable router node configuration modal
- add VPC node configuration form and modal support
- disable edges for subnetwork nodes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 66 errors, 4 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689110bcc7bc833293652d175b3b40c8