### PR TITLE
feat: open VPC canvas directly

### DIFF
--- a/src/components/common/DashboardRoutes.jsx
+++ b/src/components/common/DashboardRoutes.jsx
@@ -6,7 +6,7 @@ import PanelAdmin from '../pages/PanelAdmin';
 import { ReactFlowProvider } from "@xyflow/react";
 import MainLayout from '../layout/MainLayout';
 import { Navigate } from 'react-router-dom';
-import VPCList from '../flow/pages/VPCList';
+import VPCNew from '../flow/pages/VPCNew';
 import { LoadingFlowProvider } from '../../contexts/LoadingFlowContext';
 import LoadingFlow from './LoadingFlow';
 import SettingsPage from '../pages/SettingsPage';
@@ -66,7 +66,7 @@ const DashboardRoutes = () => {
                     <Route path='vpcs' element={
                         <>
                             <LoadingFlow />
-                            <VPCList />
+                            <VPCNew />
                         </>
                     } />
 

--- a/src/components/flow/pages/VPCNew.jsx
+++ b/src/components/flow/pages/VPCNew.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useContext } from "react";
+import { addDoc, collection } from "firebase/firestore";
+import { useNavigate } from "react-router-dom";
+import { db } from "../../../firebase/firebaseConfig";
+import { LoadingFlowContext } from "../../../contexts/LoadingFlowContext";
+import { useAuth } from "../../../contexts/AuthContext";
+import useCidrBlockVPCStore from "../store/cidrBlocksIp";
+
+const VPCNew = () => {
+    const navigate = useNavigate();
+    const { setLoadingFlow } = useContext(LoadingFlowContext);
+    const { user } = useAuth();
+    const { setCidrBlockVPC, setPrefixLength } = useCidrBlockVPCStore();
+
+    useEffect(() => {
+        const createVPC = async () => {
+            setLoadingFlow(true);
+            try {
+                const vpcDoc = await addDoc(collection(db, "vpcs"), {
+                    name: "New VPC",
+                    cloudProvider: "AWS",
+                    cidrBlock: "",
+                    userId: user?.userId,
+                    prefixLength: ""
+                });
+                setCidrBlockVPC("");
+                setPrefixLength("");
+                navigate(`/admin/vpcs/${vpcDoc.id}/mainflow`);
+            } catch (error) {
+                console.error("Error creating VPC:", error);
+            } finally {
+                setLoadingFlow(false);
+            }
+        };
+        createVPC();
+    }, [navigate, setLoadingFlow, user, setCidrBlockVPC, setPrefixLength]);
+
+    return null;
+};
+
+export default VPCNew;


### PR DESCRIPTION
## Summary
- redirect `/admin/vpcs` straight to the VPC flow by creating a new VPC behind the scenes
- wire the new VPC creation page into dashboard routes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 70 problems (66 errors, 4 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68911e0033f083328e03fddbb4cd6fde