### PR TITLE
refactor: replace VPC modal with creation page

### DIFF
--- a/src/components/common/DashboardRoutes.jsx
+++ b/src/components/common/DashboardRoutes.jsx
@@ -7,20 +7,18 @@ import { ReactFlowProvider } from "@xyflow/react";
 import MainLayout from '../layout/MainLayout';
 import { Navigate } from 'react-router-dom';
 import VPCList from '../flow/pages/VPCList';
+import CreateVPCPage from '../flow/pages/CreateVPCPage';
 import { LoadingFlowProvider } from '../../contexts/LoadingFlowContext';
 import LoadingFlow from './LoadingFlow';
 import SettingsPage from '../pages/SettingsPage';
 import { UsersManagement } from '../pages/settings/UsersManagement';
 import ProfilePage from '../pages/ProfilePage';
-import { useAuth } from '../../contexts/AuthContext';
 import { USER_ROL_STUDENT, USER_ROL_SUPER_ADMIN, USER_ROL_TEACHER } from '../../constants';
 import ProtectedRoute from './ProtectedRoute';
 import GeneralSettings from '../pages/settings/GeneralSettings';
 
 
 const DashboardRoutes = () => {
-
-    const { user } = useAuth()
 
     return (
         <LoadingFlowProvider>
@@ -67,6 +65,13 @@ const DashboardRoutes = () => {
                         <>
                             <LoadingFlow />
                             <VPCList />
+                        </>
+                    } />
+
+                    <Route path='vpcs/new' element={
+                        <>
+                            <LoadingFlow />
+                            <CreateVPCPage />
                         </>
                     } />
 

--- a/src/components/flow/pages/CreateVPCPage.jsx
+++ b/src/components/flow/pages/CreateVPCPage.jsx
@@ -1,0 +1,57 @@
+import { addDoc, collection } from 'firebase/firestore'
+import { db } from '../../../firebase/firebaseConfig'
+import { Box, Typography } from '@mui/material'
+import NewVPCForm from '../forms/NewVPCForm'
+import { useContext } from 'react'
+import { LoadingFlowContext } from '../../../contexts/LoadingFlowContext'
+import { useAuth } from '../../../contexts/AuthContext'
+import { useNavigate } from 'react-router-dom'
+import useCidrBlockVPCStore from '../store/cidrBlocksIp'
+import { DB_FIRESTORE_VPCS } from '../../../constants'
+
+const CreateVPCPage = () => {
+    const { setLoadingFlow } = useContext(LoadingFlowContext)
+    const { user } = useAuth()
+    const userId = user.userId
+    const navigate = useNavigate()
+    const { setCidrBlockVPC, setPrefixLength } = useCidrBlockVPCStore()
+
+    const handleCreateVPC = async (vpcData) => {
+        setLoadingFlow(true)
+        const { vpcName, cloudProvider, cidrBlock, prefixLength } = vpcData
+        if (vpcName && cloudProvider && cidrBlock && prefixLength) {
+            try {
+                const vpcDoc = await addDoc(collection(db, DB_FIRESTORE_VPCS), {
+                    name: vpcName,
+                    cloudProvider,
+                    cidrBlock,
+                    userId,
+                    prefixLength
+                })
+                setCidrBlockVPC(cidrBlock)
+                setPrefixLength(prefixLength)
+                navigate(`/admin/vpcs/${vpcDoc.id}/mainflow`)
+            } catch (error) {
+                // console.log(error)
+            } finally {
+                setLoadingFlow(false)
+            }
+        } else {
+            setLoadingFlow(false)
+        }
+    }
+
+    return (
+        <Box>
+            <Typography variant="h4" sx={{
+                color:(theme) => theme.palette.primary.main
+            }}>
+                Crear Nueva VPC
+            </Typography>
+            <NewVPCForm onSave={handleCreateVPC} />
+        </Box>
+    )
+}
+
+export default CreateVPCPage
+

--- a/src/components/flow/pages/VPCList.jsx
+++ b/src/components/flow/pages/VPCList.jsx
@@ -4,7 +4,6 @@ import { collection, getDocs, query, where } from 'firebase/firestore';
 import { db } from "../../../firebase/firebaseConfig";
 import { Box, Button, IconButton, Paper, Stack, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from "@mui/material";
 import AddIcon from '@mui/icons-material/Add';
-import CreateVPCModal from "./CreateVPCModal";
 import { useNavigate } from "react-router-dom";
 import { DeleteOutline } from "@mui/icons-material";
 import { ModeEditOutlined } from "@mui/icons-material";
@@ -47,7 +46,7 @@ const useFetchVPCs = (setLoadingFlow) => {
         } finally {
             setLoadingFlow(false)
         }
-    }, [setLoadingFlow, userId, user, role])
+    }, [setLoadingFlow, userId, role])
 
     useEffect(() => {
         fetchVPCs()
@@ -85,40 +84,28 @@ const fetchAllVPCs = async () => {
 
 
 const VPCList = () => {
-
-
-    const [isCreateVPCModalOpen, setIsCreateVPCModalOpen] = useState(false)
     const navigate = useNavigate()
     const { setLoadingFlow } = useContext(LoadingFlowContext)
-    const { setCidrBlockVPC, setPrefixLength } = useCidrBlockVPCStore();
+    const { setCidrBlockVPC } = useCidrBlockVPCStore();
 
     const { vpcs } = useFetchVPCs(setLoadingFlow)
-
-    const handleCreateVPCModalClose = (newVPCId, cidrBlock, prefixLength) => {
-        setCidrBlockVPC(cidrBlock)
-        setPrefixLength(prefixLength);
-        setIsCreateVPCModalOpen(false);
-        setLoadingFlow(false)
-        if (newVPCId) {
-            navigate(`/admin/vpcs/${newVPCId}/mainflow`);
-        }
-    };
 
     const handleLinkToFlow = (newVPCId, ipVPC) => {
         setLoadingFlow(true)
         setCidrBlockVPC(ipVPC)
         setLoadingFlow(false)
         navigate(`/admin/vpcs/${newVPCId}/mainflow`);
+    }
 
-
-
+    const handleNavigateToCreate = () => {
+        navigate('/admin/vpcs/new');
     }
 
 
     return (
         <div>
-            <Stack direction="column" // flex-direction: column
-                spacing={4}     >
+            <Stack direction="column"
+                spacing={4}>
                 <Stack direction="row">
                     <Box flexGrow={1} flexShrink={1} flexBasis="auto">
                         <Typography variant="h4" sx={{
@@ -128,10 +115,7 @@ const VPCList = () => {
                         </Typography>
                     </Box>
                     <div>
-                        {/* <Button variant="contained" color="primary" onClick={() => setIsCreateVPCModalOpen(true)}>
-                            Crear Nueva VPC
-                        </Button> */}
-                        <Button variant="contained" startIcon={<AddIcon/>} onClick={() => setIsCreateVPCModalOpen(true)} color="secondary">
+                        <Button variant="contained" startIcon={<AddIcon/>} onClick={handleNavigateToCreate} color="secondary">
                             Add new vpc
                         </Button>
                     </div>
@@ -139,16 +123,6 @@ const VPCList = () => {
                 </Stack>
                 <VPCsTable vpcs={vpcs} onEdit={handleLinkToFlow} />
             </Stack>
-            {/* <h2>Lista de VPCs</h2>
-            <Button variant="contained" color="primary" onClick={() => setIsCreateVPCModalOpen(true)}>
-                Crear Nueva VPC
-            </Button>
-
-
-            <VPCsTable vpcs={vpcs} onEdit={handleLinkToFlow} /> */}
-
-            <CreateVPCModal open={isCreateVPCModalOpen} onClose={handleCreateVPCModalClose} />
-
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- drop create VPC modal in list view and add button to navigate to dedicated creation page
- add standalone VPC creation page and route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous existing lint errors)*
- `npx eslint src/components/common/DashboardRoutes.jsx src/components/flow/pages/VPCList.jsx src/components/flow/pages/CreateVPCPage.jsx`

------
https://chatgpt.com/codex/tasks/task_e_6891207ece448332a9f6cb1e60a119b4